### PR TITLE
allow cache the map-snapshots on client side

### DIFF
--- a/src/api/map-snapshot/controllers/map-snapshot.ts
+++ b/src/api/map-snapshot/controllers/map-snapshot.ts
@@ -4,4 +4,12 @@
 
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::map-snapshot.map-snapshot');
+export default factories.createCoreController('api::map-snapshot.map-snapshot', () => ({
+  async findOne(ctx) {
+    //enable frontend caching as they never change
+    const result = await super.findOne(ctx);
+    // Set the Cache-Control header to cache responses for 1 day
+    ctx.res.setHeader('Cache-Control', 'max-age=86400');
+    return result
+  },
+}));


### PR DESCRIPTION
As map-snapshots never change they can be cached in frontend and are faster accessible on 2nd use.